### PR TITLE
docs/deploy: alinhar LeadOps v2.3.3 e hardening operacional

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,97 +2,213 @@
 
 Mini-CRM operacional para prospecção comercial B2B da Biotech TI.
 
-## 🚀 Status Operacional em Produção
+## Status operacional
 
-**Baseline operacional vigente:** `LeadOps DEV v1.5.5 — Consolidar WhatsApp Priority`
+**Versão do código:** `LeadOps TI v2.3.3`
 
-| Atributo | Detalhe |
+| Atributo | Valor recomendado |
 | :--- | :--- |
-| **Ambiente** | VM Ubuntu Server LTS (10.0.0.107) |
-| **Diretório Base** | `/opt/leadops` |
-| **Banco de Dados** | `/opt/leadops/data/leadops.db` |
-| **Porta Produção** | `8501` |
-| **Serviço** | `leadops-ti.service` (Systemd) |
-| **Backup** | Diário (02:00 AM) com retenção de 7 dias |
+| **Ambiente alvo** | Ubuntu Server LTS |
+| **Diretório base** | `/opt/leadops` |
+| **Banco de dados** | `/opt/leadops/data/leadops.db` |
+| **Porta padrão** | `8501` |
+| **Serviço Systemd** | `leadops-ti.service` |
+| **Backup** | Diário, com retenção mínima de 7 dias |
+
+> O repositório deve conter código, documentação e templates operacionais. Dados reais, bancos SQLite, chaves, logs e backups não devem ser versionados.
 
 ---
 
-## 🛠️ Guia Rápido de Implantação (Ubuntu Server)
+## Visão geral
 
-Para implantar esta ferramenta em um novo servidor Ubuntu Server LTS, siga os blocos de comando abaixo:
+O LeadOps TI é um CRM local leve para organizar prospecção comercial, priorizar leads, preparar abordagens e registrar histórico de contato.
 
-### 1. Preparação e Dependências
+Principais recursos:
+
+- cadastro/importação de leads;
+- deduplicação por chave operacional;
+- score e prioridade comercial;
+- funil de vendas;
+- fila diária de ação;
+- geração assistida de mensagens, e-mails e scripts de ligação;
+- registro de interações;
+- auditoria de alterações;
+- exportação CSV;
+- operação local ou em rede controlada via Streamlit.
+
+---
+
+## Stack
+
+- Python 3;
+- Streamlit;
+- Pandas;
+- SQLite;
+- Systemd para produção em servidor Linux.
+
+Dependências diretas estão em `requirements.txt`.
+
+---
+
+## Instalação rápida em Ubuntu Server
+
+### 1. Dependências do sistema
+
 ```bash
 sudo apt update && sudo apt upgrade -y
-sudo apt install -y python3-venv python3-pip git rsync
-sudo adduser --system --no-create-home --group leadops
-sudo mkdir -p /opt/leadops && sudo chown leadops:leadops /opt/leadops
+sudo apt install -y python3-venv python3-pip git rsync sqlite3
 ```
 
-### 2. Setup do Código e Ambiente Virtual
+### 2. Usuário e diretório operacional
+
+```bash
+sudo adduser --system --no-create-home --group leadops
+sudo mkdir -p /opt/leadops /etc/leadops
+sudo chown -R leadops:leadops /opt/leadops
+sudo chmod 750 /etc/leadops
+```
+
+### 3. Código e ambiente virtual
+
 ```bash
 sudo -u leadops git clone https://github.com/marcelocsjunior/CRM_LEADSOPS.git /opt/leadops
 cd /opt/leadops
 sudo -u leadops python3 -m venv .venv
+sudo -u leadops .venv/bin/pip install --upgrade pip
 sudo -u leadops .venv/bin/pip install -r requirements.txt
 ```
 
-### 3. Configuração do Serviço (Systemd)
-Crie o arquivo `/etc/systemd/system/leadops-ti.service`:
-```ini
-[Unit]
-Description=LeadOps TI CRM Service
-After=network.target
+### 4. Variáveis de ambiente
 
-[Service]
-User=leadops
-Group=leadops
-WorkingDirectory=/opt/leadops
-Environment="LEADOPS_DB=/opt/leadops/data/leadops.db"
-EnvironmentFile=/etc/leadops/leadops-ti.env
-ExecStart=/opt/leadops/.venv/bin/streamlit run app.py --server.port 8501 --server.address 0.0.0.0
-Restart=always
+```bash
+sudo cp /opt/leadops/deployment/leadops-ti.env.example /etc/leadops/leadops-ti.env
+sudo chmod 640 /etc/leadops/leadops-ti.env
+sudo chown root:leadops /etc/leadops/leadops-ti.env
 ```
 
-### 4. Ativação e Firewall
+Ajuste `/etc/leadops/leadops-ti.env` conforme o ambiente.
+
+### 5. Serviço Systemd
+
 ```bash
+sudo cp /opt/leadops/deployment/leadops-ti.service /etc/systemd/system/leadops-ti.service
 sudo systemctl daemon-reload
 sudo systemctl enable leadops-ti
 sudo systemctl start leadops-ti
+sudo systemctl status leadops-ti --no-pager
+```
+
+### 6. Firewall, quando necessário
+
+```bash
 sudo ufw allow 8501/tcp
+```
+
+Acesso padrão:
+
+```text
+http://IP_DO_SERVIDOR:8501
 ```
 
 ---
 
-## 🧠 Integração e Roteamento de IA
+## Execução local para desenvolvimento
 
-O LeadOps utiliza uma camada assistiva de IA configurada via variáveis de ambiente.
+```bash
+git clone https://github.com/marcelocsjunior/CRM_LEADSOPS.git
+cd CRM_LEADSOPS
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+streamlit run app.py
+```
 
-**Configurações em `/etc/leadops/leadops-ti.env`:**
-- `LEADOPS_AI_ENABLED=true`
-- `LEADOPS_AI_PROVIDER=gemini` (Roteamento: Gemini, Cloudflare, Local)
-- `LEADOPS_AI_MODEL=gemini-2.5-flash-lite`
+---
 
-**Regra de Ouro:**
+## Operação diária
+
+Fluxo recomendado:
+
+1. importar ou cadastrar leads;
+2. revisar a aba **Hoje**;
+3. priorizar follow-ups vencidos;
+4. trabalhar a aba **Detalhe**;
+5. copiar mensagem/e-mail/script gerado;
+6. executar contato manualmente no canal adequado;
+7. registrar a interação no CRM;
+8. revisar funil e exportações.
+
+O app não dispara WhatsApp ou e-mail automaticamente. Ele prepara o conteúdo e registra a ação depois da confirmação operacional.
+
+---
+
+## IA assistiva
+
+A camada de IA deve ser tratada como apoio operacional, não como decisor automático.
+
+Regra prática:
+
 > IA sugere. Operador revisa. Operador confirma. Sistema registra.
 
+Quando habilitada, a configuração deve ficar fora do Git, em `/etc/leadops/leadops-ti.env`.
+
+Variáveis previstas:
+
+```env
+LEADOPS_AI_ENABLED=false
+LEADOPS_AI_PROVIDER=gemini
+LEADOPS_AI_MODEL=gemini-2.5-flash-lite
+```
+
+Chaves e tokens nunca devem ser commitados.
+
 ---
 
-## 📂 Estrutura do Repositório
+## Estrutura do repositório
 
-- `leadops/`: Core da aplicação (DB, Scoring, Aging, Queue).
-- `docs/`: Documentação técnica detalhada (Arquitetura, IA, Roadmap).
-- `deployment/`: Templates de serviço, scripts de backup e guias.
-- `app.py`: Ponto de entrada da interface Streamlit.
-- `requirements.txt`: Dependências do projeto.
+```text
+.
+├── app.py
+├── leadops/
+│   ├── db.py
+│   ├── messages.py
+│   ├── scoring.py
+│   ├── utils.py
+│   └── ui/
+├── docs/
+│   ├── ARCHITECTURE.md
+│   ├── OPERATIONS.md
+│   ├── ROADMAP.md
+│   └── SECURITY_CHECKLIST.md
+├── deployment/
+│   ├── leadops-ti.env.example
+│   ├── leadops-ti.service
+│   └── backup-leadops.sh
+├── requirements.txt
+└── README.md
+```
 
 ---
 
-## 🛡️ Segurança e Higiene
+## Segurança e higiene
 
-**Não versionar:**
-- Banco SQLite real (`*.db`);
-- Arquivos de ambiente com chaves (`.env` ou `.env.local`);
-- Logs e diretórios de cache (`.cache/`).
+Não versionar:
 
-Para detalhes completos sobre a arquitetura, consulte `docs/ARCHITECTURE.md`.
+- `*.db`, `*.sqlite`, `*.sqlite3`;
+- `.env`, `.env.local`, arquivos com chaves ou tokens;
+- logs;
+- backups;
+- CSVs de clientes/leads reais;
+- dumps ou exports operacionais.
+
+O `.gitignore` já possui bloqueios para esses artefatos, mas a responsabilidade operacional continua sendo revisar antes de cada commit.
+
+---
+
+## Documentação complementar
+
+- `docs/ARCHITECTURE.md`: arquitetura e decisões técnicas;
+- `docs/OPERATIONS.md`: operação, manutenção e troubleshooting;
+- `docs/SECURITY_CHECKLIST.md`: checklist de segurança;
+- `docs/ROADMAP.md`: evolução recomendada;
+- `deployment/`: templates prontos para produção.

--- a/deployment/backup-leadops.sh
+++ b/deployment/backup-leadops.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB_PATH="${LEADOPS_DB:-/opt/leadops/data/leadops.db}"
+BACKUP_DIR="${LEADOPS_BACKUP_DIR:-/opt/leadops/data/backups}"
+RETENTION_DAYS="${LEADOPS_BACKUP_RETENTION_DAYS:-7}"
+
+if [[ ! -f "$DB_PATH" ]]; then
+  echo "Banco não encontrado: $DB_PATH" >&2
+  exit 1
+fi
+
+mkdir -p "$BACKUP_DIR"
+chmod 750 "$BACKUP_DIR"
+
+STAMP="$(date +%Y%m%d_%H%M%S)"
+TARGET="$BACKUP_DIR/leadops_${STAMP}.db"
+
+sqlite3 "$DB_PATH" ".backup '$TARGET'"
+chmod 640 "$TARGET"
+
+find "$BACKUP_DIR" -type f -name 'leadops_*.db' -mtime +"$RETENTION_DAYS" -delete
+
+echo "Backup criado: $TARGET"

--- a/deployment/leadops-ti.env.example
+++ b/deployment/leadops-ti.env.example
@@ -1,0 +1,15 @@
+# LeadOps TI — exemplo de variáveis de ambiente
+# Copiar para: /etc/leadops/leadops-ti.env
+# Não versionar o arquivo real com chaves ou tokens.
+
+LEADOPS_DB=/opt/leadops/data/leadops.db
+
+# IA assistiva. Mantenha false se não houver provedor configurado.
+LEADOPS_AI_ENABLED=false
+LEADOPS_AI_PROVIDER=gemini
+LEADOPS_AI_MODEL=gemini-2.5-flash-lite
+
+# Exemplo. Não preencher chaves reais neste arquivo versionado.
+# GEMINI_API_KEY=
+# CLOUDFLARE_ACCOUNT_ID=
+# CLOUDFLARE_API_TOKEN=

--- a/deployment/leadops-ti.service
+++ b/deployment/leadops-ti.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=LeadOps TI CRM Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=leadops
+Group=leadops
+WorkingDirectory=/opt/leadops
+EnvironmentFile=/etc/leadops/leadops-ti.env
+ExecStart=/opt/leadops/.venv/bin/streamlit run app.py --server.port 8501 --server.address 0.0.0.0 --server.headless true
+Restart=always
+RestartSec=5
+TimeoutStartSec=60
+
+# Hardening leve, compatível com SQLite local.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ReadWritePaths=/opt/leadops/data
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,126 @@
+# Operação — LeadOps TI
+
+## Objetivo
+
+Este guia organiza execução, manutenção e recuperação operacional do LeadOps TI em ambiente local ou servidor Ubuntu.
+
+## Execução local
+
+```bash
+cd CRM_LEADSOPS
+source .venv/bin/activate
+streamlit run app.py
+```
+
+Acesse:
+
+```text
+http://localhost:8501
+```
+
+## Execução em servidor
+
+Padrão recomendado:
+
+```bash
+sudo systemctl status leadops-ti --no-pager
+sudo journalctl -u leadops-ti -n 100 --no-pager
+```
+
+Reiniciar:
+
+```bash
+sudo systemctl restart leadops-ti
+```
+
+Parar:
+
+```bash
+sudo systemctl stop leadops-ti
+```
+
+Subir no boot:
+
+```bash
+sudo systemctl enable leadops-ti
+```
+
+## Banco de dados
+
+Caminho recomendado:
+
+```text
+/opt/leadops/data/leadops.db
+```
+
+Antes de manutenção relevante, gere backup:
+
+```bash
+sudo -u leadops mkdir -p /opt/leadops/data/backups
+sudo -u leadops cp /opt/leadops/data/leadops.db /opt/leadops/data/backups/leadops_manual_$(date +%Y%m%d_%H%M%S).db
+```
+
+## Atualização de código em produção
+
+```bash
+cd /opt/leadops
+sudo systemctl stop leadops-ti
+sudo -u leadops git pull --ff-only
+sudo -u leadops .venv/bin/pip install -r requirements.txt
+sudo systemctl start leadops-ti
+sudo systemctl status leadops-ti --no-pager
+```
+
+## Verificações pós-atualização
+
+- app abre na porta `8501`;
+- banco foi preservado;
+- leads aparecem na aba Leads;
+- aba Hoje carrega sem erro;
+- aba Detalhe permite navegar na fila;
+- registro de interação funciona;
+- exportação CSV funciona.
+
+## Troubleshooting
+
+### Serviço não sobe
+
+```bash
+sudo journalctl -u leadops-ti -n 200 --no-pager
+```
+
+Verifique:
+
+- caminho `/opt/leadops`;
+- existência da `.venv`;
+- permissões do usuário `leadops`;
+- arquivo `/etc/leadops/leadops-ti.env`;
+- dependências do `requirements.txt`.
+
+### Porta ocupada
+
+```bash
+sudo ss -ltnp | grep 8501
+```
+
+### Banco sem permissão
+
+```bash
+sudo chown -R leadops:leadops /opt/leadops/data
+```
+
+### App sem dados
+
+Verifique se `LEADOPS_DB` aponta para o banco correto.
+
+## Rotina mínima semanal
+
+- revisar backups;
+- testar abertura do app;
+- exportar base CSV quando necessário;
+- revisar logs do serviço;
+- confirmar espaço em disco.
+
+## Regra operacional
+
+O LeadOps prepara abordagem e registra histórico. O envio de mensagem, e-mail ou ligação continua sendo ação humana fora do sistema.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,43 +1,98 @@
 # Roadmap — LeadOps TI / Mini CRM Biotech
 
+## Estado atual
+
+A versão operacional atual do código é `v2.3.3`.
+
+A linha atual consolidou:
+
+- aba Detalhe como fila operacional;
+- filtro de novos/não contactados;
+- recomendação de próxima ação;
+- funil comercial padronizado;
+- auditoria de alterações;
+- templates de abordagem;
+- documentação e templates iniciais de deploy.
+
+---
+
 ## Prioridade imediata
 
 ### 1. Operação comercial disciplinada
 
 - reduzir estoque de leads em **Novo**;
-- trabalhar com mais ritmo os leads em **Contatado**;
-- amadurecer o lead em **Respondeu**;
-- registrar toda interação no CRM.
+- trabalhar leads **Contatados** com cadência definida;
+- avançar leads em **Respondeu** para qualificação;
+- registrar toda interação no CRM;
+- respeitar status **Não contatar**.
 
-### 2. Inteligência operacional adicional
+### 2. Endurecimento operacional
 
-- ampliar lógica de follow-up vencido;
-- reforçar visão de aging por etapa;
-- melhorar ainda mais a fila diária de ação;
-- refinar a cadência comercial.
+- usar serviço Systemd em servidor;
+- manter banco real fora do Git;
+- executar backup diário;
+- testar restauração;
+- restringir exposição de rede;
+- revisar permissões de `/opt/leadops` e `/etc/leadops`.
 
-### 3. Endurecimento operacional
+### 3. Governança do repositório
 
-- revisar exposição do Streamlit em rede;
-- preferir uso local ou rede interna controlada;
-- avaliar binding mais restrito quando necessário;
-- considerar autostart no notebook.
+- manter README, versão do código e documentação sem drift;
+- criar changelog por versão;
+- manter templates de deploy atualizados;
+- evitar commit de artefatos sensíveis;
+- estruturar releases quando houver marco estável.
 
-## Próxima camada de evolução
+---
 
-### 4. Repositório e governança
+## Próxima camada técnica
 
-- publicar o código-fonte operacional de forma organizada;
-- manter README, changelog e documentação sem drift;
-- estruturar releases por versão;
-- evitar versionamento de dados reais e artefatos sensíveis.
+### 4. Testes mínimos
 
-### 5. Evoluções futuras do produto
+Criar testes para:
 
-- dashboards adicionais;
-- refinamento contínuo do score;
-- maior inteligência de priorização por contexto;
-- melhorias extras no uso móvel.
+- scoring;
+- normalização de telefone/e-mail/domínio;
+- geração de `lead_key`;
+- migração inicial do banco;
+- preservação de estado comercial em importações.
+
+### 5. Diagnóstico operacional
+
+Adicionar tela ou comando de diagnóstico com:
+
+- caminho do banco atual;
+- total de leads;
+- total de interações;
+- último contato registrado;
+- status da configuração de IA;
+- versão do app;
+- alertas de permissões ou banco ausente.
+
+### 6. Segurança de acesso
+
+Avaliar, conforme cenário:
+
+- VPN;
+- túnel autenticado;
+- reverse proxy com autenticação;
+- binding local quando o uso for apenas no servidor;
+- segmentação de rede.
+
+---
+
+## Evoluções futuras do produto
+
+- dashboards adicionais por cidade, segmento e fonte;
+- revisão contínua dos pesos de score;
+- suporte a importadores mais robustos;
+- cadência configurável por perfil de lead;
+- exportação segmentada;
+- integração assistiva de IA com fallback;
+- histórico de objeções;
+- indicadores de conversão por canal.
+
+---
 
 ## Regra prática
 
@@ -47,4 +102,5 @@ Toda evolução deve preservar:
 - rollback fácil;
 - segurança dos dados;
 - baixa fricção de uso;
-- aderência ao fluxo comercial real.
+- aderência ao fluxo comercial real;
+- decisão humana antes de ação externa.

--- a/docs/SECURITY_CHECKLIST.md
+++ b/docs/SECURITY_CHECKLIST.md
@@ -1,0 +1,105 @@
+# Checklist de Segurança — LeadOps TI
+
+## Escopo
+
+Checklist para reduzir risco operacional no uso do LeadOps TI em notebook, VM ou servidor Ubuntu.
+
+## Dados e versionamento
+
+Antes de qualquer commit, confirmar:
+
+- nenhum banco real foi adicionado;
+- nenhum CSV real de leads/clientes foi adicionado;
+- nenhum arquivo `.env` foi adicionado;
+- nenhum token, senha ou chave de API aparece no diff;
+- nenhum log operacional foi adicionado;
+- nenhum backup foi adicionado.
+
+Comandos úteis:
+
+```bash
+git status --short
+git diff --cached
+```
+
+## Arquivos sensíveis bloqueados
+
+O `.gitignore` deve bloquear, no mínimo:
+
+```text
+.env
+*.db
+*.sqlite
+*.sqlite3
+*.log
+backups/
+exports/
+secrets/
+private/
+data/private/
+data/raw/
+```
+
+## Permissões recomendadas no servidor
+
+```bash
+sudo chown -R leadops:leadops /opt/leadops
+sudo chmod 750 /opt/leadops
+sudo chmod 750 /etc/leadops
+sudo chmod 640 /etc/leadops/leadops-ti.env
+sudo chown root:leadops /etc/leadops/leadops-ti.env
+```
+
+## Exposição de rede
+
+Preferência operacional:
+
+1. uso local;
+2. LAN controlada;
+3. VPN;
+4. túnel autenticado;
+5. reverse proxy com autenticação.
+
+Evitar exposição pública direta do Streamlit sem camada adicional de proteção.
+
+## Variáveis de ambiente
+
+Arquivo recomendado:
+
+```text
+/etc/leadops/leadops-ti.env
+```
+
+Conteúdo mínimo:
+
+```env
+LEADOPS_DB=/opt/leadops/data/leadops.db
+LEADOPS_AI_ENABLED=false
+LEADOPS_AI_PROVIDER=gemini
+LEADOPS_AI_MODEL=gemini-2.5-flash-lite
+```
+
+Chaves reais devem ser adicionadas apenas no servidor e nunca no Git.
+
+## Backup
+
+- gerar backup antes de atualização;
+- manter retenção mínima de 7 dias;
+- validar restauração periodicamente;
+- proteger diretório de backup contra leitura indevida.
+
+## Operação comercial
+
+- respeitar marcação `Não contatar`;
+- registrar motivo quando remover lead da cadência;
+- não automatizar envio sem validação humana;
+- manter histórico de interação atualizado.
+
+## Revisão antes de produção
+
+- serviço Systemd ativo;
+- banco em caminho esperado;
+- firewall coerente com o cenário;
+- logs sem erro crítico;
+- backup testado;
+- documentação alinhada com a versão do código.


### PR DESCRIPTION
## Resumo

- Alinha o README à versão atual do código: `LeadOps TI v2.3.3`.
- Adiciona guia operacional em `docs/OPERATIONS.md`.
- Adiciona checklist de segurança em `docs/SECURITY_CHECKLIST.md`.
- Adiciona templates de deploy em `deployment/`:
  - `leadops-ti.service`
  - `leadops-ti.env.example`
  - `backup-leadops.sh`
- Atualiza o roadmap com governança, backup, segurança e próximos testes mínimos.

## Observações

- Não altera código de aplicação.
- Não altera banco de dados.
- Não adiciona segredos.
- Branch criada a partir da `main` atual, sem divergência.

## Validação feita

- Comparação `main` x branch: branch está `ahead`, `behind_by=0`.
- Mudanças restritas a documentação e templates operacionais.